### PR TITLE
Update stops.txt definition

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -78,7 +78,7 @@ This specification defines the following files:
 |  Filename | Required | Defines |
 |  ------ | ------ | ------ |
 |  [agency.txt](#agencytxt) | **Required** | Transit agencies with service represented in this dataset. |
-|  [stops.txt](#stopstxt) | **Required** | Stops where vehicles pick up or drop off riders. Also defines stations and station entrances.  |
+|  [stops.txt](#stopstxt) | **Required** | Stops where vehicles pick up or drop off riders. Also defines other locations related to station navigation.  |
 |  [routes.txt](#routestxt) | **Required** | Transit routes. A route is a group of trips that are displayed to riders as a single service. |
 |  [trips.txt](#tripstxt)  | **Required** | Trips for each route. A trip is a sequence of two or more stops that occur during a specific time period. |
 |  [stop_times.txt](#stop_timestxt)  | **Required** | Times that a vehicle arrives at and departs from stops for each trip. |


### PR DESCRIPTION
In addition to the update to `stop_id`, update stops.txt dataset file definition to generalize "locations".